### PR TITLE
fix redirects with #

### DIFF
--- a/web/redirect.html
+++ b/web/redirect.html
@@ -45,8 +45,10 @@
     (function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","https://www.google-analytics.com/analytics.js","ga");
     ga("create", "UA-60403362-9", "auto");
     ga("send", "pageview");
-
-    const url = decodeURIComponent(window.location.pathname.replace(/^\//,""));
+    
+    const site = window.location.protocol + "//" + window.location.host;
+    const url = decodeURIComponent(window.location.href.replace(site,"").replace(/^\//,""));
+  
     if (url) {
       setTimeout(() => {
         window.location = "lbry://" + url;


### PR DESCRIPTION
Previously, the window.location.path would return the URL without the contents after a #. It's possible that a user generated this type of URL manually or got it from the LBRY app.