### PR TITLE
pages such as ?rewards correctly redirect

### DIFF
--- a/web/redirect.html
+++ b/web/redirect.html
@@ -165,7 +165,11 @@
         if (prefix === APP_PREFIX)
           window.location = prefix + url.replace(/:/g, "#");
         else {
-          window.location = prefix + url;
+          if (url[0] === '?') {
+            window.location = `${prefix}$/${url.slice(1)}`
+          } else {
+            window.location = `${prefix}${url}`;
+          }
         }
       }
 


### PR DESCRIPTION
also tested url/?wallet, url/?, and url/# and it handled them fine.